### PR TITLE
Remove dispatch_sync call on the same queue from dealloc in order to …

### DIFF
--- a/PocketSocket/PSWebSocketServer.m
+++ b/PocketSocket/PSWebSocketServer.m
@@ -681,9 +681,7 @@ void PSWebSocketServerAcceptCallback(CFSocketRef s, CFSocketCallBackType type, C
 #pragma mark - Dealloc
 
 - (void)dealloc {
-    [self executeWorkAndWait:^{
-        [self disconnect:YES];
-    }];
+    [self disconnect:YES];
 }
 
 @end


### PR DESCRIPTION
…avoid deadlock

See: https://github.com/clario-tech/PocketSocket/pull/3